### PR TITLE
Fix energy metering bugs and improve accuracy

### DIFF
--- a/src/energy_meter/macos_meter.py
+++ b/src/energy_meter/macos_meter.py
@@ -183,35 +183,96 @@ class MacosMeter(EnergyMeter):
         """
         power_samples = []
 
-        # Look for patterns in cpu_power sampler output
-        # Examples: "CPU Power: 1234 mW", "Combined Power (CPU + GPU + ANE): 1234 mW"
-        patterns = [
-            r"Combined Power \(CPU \+ GPU \+ ANE\):\s+([\d.]+)\s+mW",
-            r"CPU Power:\s+([\d.]+)\s+mW",
-            r"GPU Power:\s+([\d.]+)\s+mW",
-            r"Package Power:\s+([\d.]+)\s+mW",
-        ]
+        # Regex to identify start of a sample block
+        # "*** Sampled system activity (Thu Jan  1 00:00:00 1970) (5000.00ms elapsed) ***"
+        sample_header_pattern = r"\*\*\* Sampled system activity .* \*\*\*"
+
+        # Patterns for power
+        combined_pattern = r"Combined Power \(CPU \+ GPU \+ ANE\):\s+([\d.]+)\s+mW"
+        cpu_pattern = r"CPU Power:\s+([\d.]+)\s+mW"
+        gpu_pattern = r"GPU Power:\s+([\d.]+)\s+mW"
+        package_pattern = r"Package Power:\s+([\d.]+)\s+mW"
+
+        current_block_values: Dict[str, float] = {}
+        in_block = False
 
         for line in self.output_lines:
-            # Prioritize Combined Power as it includes CPU + GPU + ANE
-            match = re.search(r"Combined Power \(CPU \+ GPU \+ ANE\):\s+([\d.]+)\s+mW", line)
-            if match:
-                try:
-                    power_mw = float(match.group(1))
-                    power_samples.append(power_mw)
-                    continue  # Found combined power, skip other patterns for this line
-                except (ValueError, IndexError):
-                    pass
+            if re.search(sample_header_pattern, line):
+                # New block found. Process previous block if exists.
+                if in_block:
+                    val = self._calculate_block_power(current_block_values)
+                    if val is not None:
+                        power_samples.append(val)
+
+                # Reset for new block
+                current_block_values = {}
+                in_block = True
+                continue
             
-            # If no combined power, try individual patterns
-            for pattern in patterns[1:]:  # Skip combined power pattern
-                match = re.search(pattern, line)
+            if in_block:
+                # Try to extract power values
+                match = re.search(combined_pattern, line)
                 if match:
                     try:
-                        power_mw = float(match.group(1))
-                        power_samples.append(power_mw)
-                        break  # Found a match, move to next line
-                    except (ValueError, IndexError):
+                        current_block_values['combined'] = float(match.group(1))
                         continue
+                    except (ValueError, IndexError):
+                        pass
+
+                match = re.search(cpu_pattern, line)
+                if match:
+                    try:
+                        current_block_values['cpu'] = float(match.group(1))
+                        continue
+                    except (ValueError, IndexError):
+                        pass
+
+                match = re.search(gpu_pattern, line)
+                if match:
+                    try:
+                        current_block_values['gpu'] = float(match.group(1))
+                        continue
+                    except (ValueError, IndexError):
+                        pass
+
+                match = re.search(package_pattern, line)
+                if match:
+                    try:
+                        current_block_values['package'] = float(match.group(1))
+                        continue
+                    except (ValueError, IndexError):
+                        pass
+
+        # Process the last block
+        if in_block:
+            val = self._calculate_block_power(current_block_values)
+            if val is not None:
+                power_samples.append(val)
 
         return power_samples
+
+    def _calculate_block_power(self, values: Dict[str, float]) -> Optional[float]:
+        """Calculate total power from a block of parsed values."""
+        if 'combined' in values:
+            return values['combined']
+
+        # If we have Package Power, it usually covers CPU (and maybe GPU/system)
+        # But prefer summing specific components if known, or fallback to Package if it's the only thing.
+        # Actually, Combined is best. If not, CPU + GPU is usually what we want.
+
+        total = 0.0
+        found = False
+        if 'cpu' in values:
+            total += values['cpu']
+            found = True
+        if 'gpu' in values:
+            total += values['gpu']
+            found = True
+
+        if found:
+            return total
+
+        if 'package' in values:
+            return values['package']
+
+        return None

--- a/src/energy_meter/nvml_meter.py
+++ b/src/energy_meter/nvml_meter.py
@@ -2,7 +2,7 @@
 
 import threading
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 try:
     import pynvml
@@ -33,7 +33,7 @@ class NvmlMeter(EnergyMeter):
         self.device_index = device_index
         self.handle: Optional[any] = None
         self.thread: Optional[threading.Thread] = None
-        self.power_samples: List[float] = []
+        self.power_samples: List[Tuple[float, float]] = []
         self.start_time: float = 0.0
         self.stop_time: float = 0.0
         self._running: bool = False
@@ -90,7 +90,7 @@ class NvmlMeter(EnergyMeter):
             try:
                 # Get power in milliwatts
                 power_mw = pynvml.nvmlDeviceGetPowerUsage(self.handle)
-                self.power_samples.append(power_mw)
+                self.power_samples.append((time.time(), power_mw))
             except Exception:
                 # If we can't read power, skip this sample
                 pass
@@ -126,22 +126,37 @@ class NvmlMeter(EnergyMeter):
 
         # Calculate energy using trapezoidal integration
         if len(self.power_samples) < 2:
-            return {
-                "energy_wh_raw": 0.0,
-                "duration_s": duration_s,
-                "sampling_ms": self.sampling_ms,
-            }
+            # Fallback logic for very short duration
+            if len(self.power_samples) == 1:
+                # Use the single sample as average power
+                _, power_mw = self.power_samples[0]
+                avg_power_watts = power_mw / 1000.0
+                energy_wh = avg_power_watts * (duration_s / 3600.0)
+                return {
+                    "energy_wh_raw": energy_wh,
+                    "duration_s": duration_s,
+                    "sampling_ms": self.sampling_ms,
+                }
+            else:
+                return {
+                    "energy_wh_raw": 0.0,
+                    "duration_s": duration_s,
+                    "sampling_ms": self.sampling_ms,
+                }
 
-        # Convert power from milliwatts to watts
-        power_watts = [p / 1000.0 for p in self.power_samples]
-
-        # Time between samples in hours
-        dt_hours = (self.sampling_ms / 1000.0) / 3600.0
-
-        # Trapezoidal integration
+        # Trapezoidal integration using actual timestamps
         energy_wh = 0.0
-        for i in range(len(power_watts) - 1):
-            avg_power = (power_watts[i] + power_watts[i + 1]) / 2.0
+        for i in range(len(self.power_samples) - 1):
+            t1, p1_mw = self.power_samples[i]
+            t2, p2_mw = self.power_samples[i+1]
+
+            p1_w = p1_mw / 1000.0
+            p2_w = p2_mw / 1000.0
+
+            # Time difference in hours
+            dt_hours = (t2 - t1) / 3600.0
+
+            avg_power = (p1_w + p2_w) / 2.0
             energy_wh += avg_power * dt_hours
 
         return {

--- a/src/energy_meter/rapl_meter.py
+++ b/src/energy_meter/rapl_meter.py
@@ -4,7 +4,7 @@ import glob
 import os
 import time
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from .base import EnergyMeter
 
@@ -26,8 +26,8 @@ class RaplMeter(EnergyMeter):
             sampling_ms: Sampling interval (not used for RAPL, but kept for consistency).
         """
         self.sampling_ms = sampling_ms
-        self.rapl_path: Optional[Path] = None
-        self.start_energy_uj: float = 0.0
+        self.rapl_paths: List[Path] = []
+        self.start_energy_uj: Dict[Path, float] = {}
         self.start_time: float = 0.0
         self.stop_time: float = 0.0
 
@@ -43,17 +43,24 @@ class RaplMeter(EnergyMeter):
         if not rapl_base.exists():
             return False
 
-        # Find RAPL zones
+        # Find all RAPL zones
         rapl_zones = list(rapl_base.glob("intel-rapl:*"))
+        self.rapl_paths = []
 
-        # Check if any zone has an energy_uj file
         for zone in rapl_zones:
+            name_file = zone / "name"
             energy_file = zone / "energy_uj"
-            if energy_file.exists():
-                self.rapl_path = zone
-                return True
 
-        return False
+            if name_file.exists() and energy_file.exists():
+                try:
+                    name = name_file.read_text().strip()
+                    # Only collect from package zones to avoid double counting cores
+                    if "package" in name:
+                        self.rapl_paths.append(zone)
+                except Exception:
+                    continue
+
+        return len(self.rapl_paths) > 0
 
     def start(self) -> None:
         """
@@ -70,8 +77,8 @@ class RaplMeter(EnergyMeter):
             )
 
         # Check permissions explicitly
-        if self.rapl_path:
-            energy_file = self.rapl_path / "energy_uj"
+        for path in self.rapl_paths:
+            energy_file = path / "energy_uj"
             if not os.access(energy_file, os.R_OK):
                 raise PermissionError(
                     f"Permission denied reading {energy_file}. "
@@ -79,11 +86,13 @@ class RaplMeter(EnergyMeter):
                 )
 
         self.start_time = time.time()
+        self.start_energy_uj = {}
 
-        # Read initial energy value
-        self.start_energy_uj = self._read_energy_uj()
+        # Read initial energy value for all zones
+        for path in self.rapl_paths:
+            self.start_energy_uj[path] = self._read_energy_uj(path)
 
-    def _read_energy_uj(self) -> float:
+    def _read_energy_uj(self, path: Path) -> float:
         """
         Read the current energy counter value in microjoules.
 
@@ -93,17 +102,14 @@ class RaplMeter(EnergyMeter):
         Raises:
             RuntimeError: If reading fails.
         """
-        if self.rapl_path is None:
-            raise RuntimeError("RAPL path not initialized")
-
-        energy_file = self.rapl_path / "energy_uj"
+        energy_file = path / "energy_uj"
 
         try:
             with open(energy_file, "r") as f:
                 energy_uj_str = f.read().strip()
                 return float(energy_uj_str)
         except Exception as e:
-            raise RuntimeError(f"Failed to read RAPL energy counter: {e}")
+            raise RuntimeError(f"Failed to read RAPL energy counter at {path}: {e}")
 
     def stop(self) -> Dict[str, float]:
         """
@@ -119,28 +125,32 @@ class RaplMeter(EnergyMeter):
             RuntimeError: If reading the energy counter fails.
         """
         self.stop_time = time.time()
-
-        # Read final energy value
-        stop_energy_uj = self._read_energy_uj()
-
         duration_s = self.stop_time - self.start_time
 
-        # Calculate energy difference in microjoules
-        energy_diff_uj = stop_energy_uj - self.start_energy_uj
+        total_energy_wh = 0.0
 
-        # Handle counter wrap-around (RAPL counters can overflow)
-        # Typical RAPL counter max is around 2^32 microjoules
-        if energy_diff_uj < 0:
-            # Assume counter wrapped once
-            max_counter = 2**32
-            energy_diff_uj += max_counter
+        for path in self.rapl_paths:
+            # Read final energy value
+            stop_energy_uj = self._read_energy_uj(path)
+            start_energy_uj = self.start_energy_uj.get(path, 0.0)
 
-        # Convert microjoules to watt-hours
-        # 1 Wh = 3,600,000,000 microjoules
-        energy_wh = energy_diff_uj / 3_600_000_000.0
+            # Calculate energy difference in microjoules
+            energy_diff_uj = stop_energy_uj - start_energy_uj
+
+            # Handle counter wrap-around (RAPL counters can overflow)
+            # Typical RAPL counter max is around 2^32 microjoules
+            if energy_diff_uj < 0:
+                # Assume counter wrapped once
+                max_counter = 2**32
+                energy_diff_uj += max_counter
+
+            # Convert microjoules to watt-hours
+            # 1 Wh = 3,600,000,000 microjoules
+            energy_wh = energy_diff_uj / 3_600_000_000.0
+            total_energy_wh += energy_wh
 
         return {
-            "energy_wh_raw": energy_wh,
+            "energy_wh_raw": total_energy_wh,
             "duration_s": duration_s,
             "sampling_ms": self.sampling_ms,
         }

--- a/src/energy_meter/rocm_smi_meter.py
+++ b/src/energy_meter/rocm_smi_meter.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import threading
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from .base import EnergyMeter
 
@@ -30,7 +30,7 @@ class RocmSmiMeter(EnergyMeter):
         self.sampling_ms = sampling_ms
         self.device_index = device_index
         self.thread: Optional[threading.Thread] = None
-        self.power_samples: List[float] = []
+        self.power_samples: List[Tuple[float, float]] = []
         self.start_time: float = 0.0
         self.stop_time: float = 0.0
         self._running: bool = False
@@ -84,7 +84,7 @@ class RocmSmiMeter(EnergyMeter):
                 if result.returncode == 0:
                     power_watts = self._parse_power(result.stdout)
                     if power_watts is not None:
-                        self.power_samples.append(power_watts)
+                        self.power_samples.append((time.time(), power_watts))
 
             except (subprocess.TimeoutExpired, Exception):
                 # If we can't read power, skip this sample
@@ -141,22 +141,32 @@ class RocmSmiMeter(EnergyMeter):
 
         # Calculate energy using trapezoidal integration
         if len(self.power_samples) < 2:
-            return {
-                "energy_wh_raw": 0.0,
-                "duration_s": duration_s,
-                "sampling_ms": self.sampling_ms,
-            }
+            if len(self.power_samples) == 1:
+                # Use the single sample as average power
+                _, power_watts = self.power_samples[0]
+                energy_wh = power_watts * (duration_s / 3600.0)
+                return {
+                    "energy_wh_raw": energy_wh,
+                    "duration_s": duration_s,
+                    "sampling_ms": self.sampling_ms,
+                }
+            else:
+                return {
+                    "energy_wh_raw": 0.0,
+                    "duration_s": duration_s,
+                    "sampling_ms": self.sampling_ms,
+                }
 
-        # Power is already in watts
-        power_watts = self.power_samples
-
-        # Time between samples in hours
-        dt_hours = (self.sampling_ms / 1000.0) / 3600.0
-
-        # Trapezoidal integration
+        # Trapezoidal integration using actual timestamps
         energy_wh = 0.0
-        for i in range(len(power_watts) - 1):
-            avg_power = (power_watts[i] + power_watts[i + 1]) / 2.0
+        for i in range(len(self.power_samples) - 1):
+            t1, p1_watts = self.power_samples[i]
+            t2, p2_watts = self.power_samples[i+1]
+
+            # Time difference in hours
+            dt_hours = (t2 - t1) / 3600.0
+
+            avg_power = (p1_watts + p2_watts) / 2.0
             energy_wh += avg_power * dt_hours
 
         return {

--- a/src/main.py
+++ b/src/main.py
@@ -248,6 +248,7 @@ def run_test(
 
     # Initialize energy meter
     console.print("[yellow]Initializing energy meter...[/yellow]")
+    meter = None
     try:
         meter = get_platform_meter(sampling_ms=sampling_ms)
         console.print(
@@ -261,7 +262,7 @@ def run_test(
     def cleanup():
         try:
             # Attempt to stop the meter if it was initialized
-            if 'meter' in locals() and meter and hasattr(meter, 'stop'):
+            if meter and hasattr(meter, 'stop'):
                  try:
                      meter.stop()
                  except Exception:

--- a/tests/test_meters_fixes.py
+++ b/tests/test_meters_fixes.py
@@ -1,0 +1,136 @@
+
+import unittest
+import time
+from unittest.mock import MagicMock, patch
+from src.energy_meter.macos_meter import MacosMeter
+from src.energy_meter.nvml_meter import NvmlMeter
+from src.energy_meter.rapl_meter import RaplMeter
+from src.energy_meter.rocm_smi_meter import RocmSmiMeter
+
+class TestEnergyMetersFixes(unittest.TestCase):
+    def test_macos_parsing_header_separation(self):
+        meter = MacosMeter()
+        meter.output_lines = [
+            "*** Sampled system activity (Thu Jan  1 00:00:00 1970) (5000.00ms elapsed) ***",
+            "CPU Power: 100 mW",
+            "GPU Power: 50 mW",
+            "Package Power: 150 mW",
+
+            "*** Sampled system activity (Thu Jan  1 00:00:01 1970) (5100.00ms elapsed) ***",
+            "CPU Power: 100 mW",
+            "GPU Power: 50 mW",
+        ]
+        samples = meter._parse_power_samples()
+        # Should result in 2 samples, 150 and 150.
+        self.assertEqual(len(samples), 2)
+        self.assertEqual(samples[0], 150.0)
+        self.assertEqual(samples[1], 150.0)
+
+    def test_macos_parsing_combined(self):
+        meter = MacosMeter()
+        meter.output_lines = [
+            "*** Sampled system activity (Thu Jan  1 00:00:00 1970) (5000.00ms elapsed) ***",
+            "CPU Power: 100 mW",
+            "Combined Power (CPU + GPU + ANE): 200 mW",
+        ]
+        samples = meter._parse_power_samples()
+        self.assertEqual(len(samples), 1)
+        self.assertEqual(samples[0], 200.0)
+
+    @patch('src.energy_meter.nvml_meter.pynvml')
+    def test_nvml_integration_logic(self, mock_pynvml):
+        meter = NvmlMeter()
+        mock_pynvml.nvmlInit.return_value = None
+        meter._nvml_initialized = True
+
+        # Manually populate samples with known timestamps
+        t0 = 1000.0
+        meter.start_time = t0
+        meter.power_samples = [
+            (t0, 10000.0),      # 10 W
+            (t0 + 1.0, 10000.0), # 10 W, dt=1s
+            (t0 + 2.0, 20000.0), # 20 W, dt=1s
+        ]
+        meter.stop_time = t0 + 2.0
+
+        meter.start = MagicMock()
+
+        with patch.object(meter, '_running', False):
+             result = meter.stop()
+
+        expected_wh = 25.0 / 3600.0
+        self.assertAlmostEqual(result['energy_wh_raw'], expected_wh, places=6)
+
+    @patch('src.energy_meter.rocm_smi_meter.subprocess.run')
+    def test_rocm_integration_logic(self, mock_run):
+        meter = RocmSmiMeter()
+
+        t0 = 1000.0
+        meter.start_time = t0
+        meter.power_samples = [
+            (t0, 10.0),      # 10 W
+            (t0 + 1.0, 10.0), # 10 W
+            (t0 + 2.0, 20.0), # 20 W
+        ]
+        meter.stop_time = t0 + 2.0
+
+        with patch.object(meter, '_running', False):
+             result = meter.stop()
+
+        expected_wh = 25.0 / 3600.0
+        self.assertAlmostEqual(result['energy_wh_raw'], expected_wh, places=6)
+
+    @patch('src.energy_meter.rapl_meter.Path')
+    def test_rapl_zone_selection(self, mock_path_cls):
+        mock_base = MagicMock()
+        mock_path_cls.return_value = mock_base
+        mock_base.exists.return_value = True
+
+        zone0 = MagicMock()
+        zone0_name = MagicMock()
+        zone0_name.exists.return_value = True
+        zone0_name.read_text.return_value = "package-0\n"
+        zone0_energy = MagicMock()
+        zone0_energy.exists.return_value = True
+
+        def zone0_div(other):
+            if other == "name": return zone0_name
+            if other == "energy_uj": return zone0_energy
+            return MagicMock()
+        zone0.__truediv__.side_effect = zone0_div
+
+        zone00 = MagicMock()
+        zone00_name = MagicMock()
+        zone00_name.exists.return_value = True
+        zone00_name.read_text.return_value = "core\n"
+        zone00_energy = MagicMock()
+        zone00_energy.exists.return_value = True
+
+        def zone00_div(other):
+            if other == "name": return zone00_name
+            if other == "energy_uj": return zone00_energy
+            return MagicMock()
+        zone00.__truediv__.side_effect = zone00_div
+
+        zone1 = MagicMock()
+        zone1_name = MagicMock()
+        zone1_name.exists.return_value = True
+        zone1_name.read_text.return_value = "package-1\n"
+        zone1_energy = MagicMock()
+        zone1_energy.exists.return_value = True
+
+        def zone1_div(other):
+            if other == "name": return zone1_name
+            if other == "energy_uj": return zone1_energy
+            return MagicMock()
+        zone1.__truediv__.side_effect = zone1_div
+
+        mock_base.glob.return_value = [zone0, zone00, zone1]
+
+        meter = RaplMeter()
+        meter.is_available()
+
+        self.assertIn(zone0, meter.rapl_paths)
+        self.assertIn(zone1, meter.rapl_paths)
+        self.assertNotIn(zone00, meter.rapl_paths)
+        self.assertEqual(len(meter.rapl_paths), 2)


### PR DESCRIPTION
This PR fixes several critical bugs in the energy metering logic:

1.  **MacosMeter**: The parsing logic was incorrect, treating every regex match as a new time sample. This led to incorrect energy calculations. The fix groups matches by sample block.
2.  **NvmlMeter** and **RocmSmiMeter**: The integration loop relied on `time.sleep(interval)` and assumed fixed `dt` for integration. This introduced drift and underestimated energy. The fix uses actual timestamps for Trapezoidal integration.
3.  **RaplMeter**: It only selected the first available RAPL zone. The fix ensures all "package" zones are measured (important for multi-socket systems) and avoids double counting sub-zones.
4.  **Cleanup**: Fixed a bug in `main.py` where the cleanup handler could fail if `meter` wasn't initialized.

Added `tests/test_meters_fixes.py` to verify the fixes.

---
*PR created automatically by Jules for task [12458908901807147936](https://jules.google.com/task/12458908901807147936) started by @NOVADEDOG*